### PR TITLE
Use extreme TPC average for key signature adjustment

### DIFF
--- a/RespellCSharpToDb.qml
+++ b/RespellCSharpToDb.qml
@@ -58,11 +58,18 @@ MuseScore {
         if (!notes.length)
             return;
 
-        var totalTpc = 0;
-        for (var i = 0; i < notes.length; i++)
-            totalTpc += notes[i].tpc;
+        var minTpc = notes[0].tpc;
+        var maxTpc = notes[0].tpc;
 
-        var averageTpc = totalTpc / notes.length;
+        for (var i = 1; i < notes.length; i++) {
+            var tpc = notes[i].tpc;
+            if (tpc < minTpc)
+                minTpc = tpc;
+            if (tpc > maxTpc)
+                maxTpc = tpc;
+        }
+
+        var averageTpc = (minTpc + maxTpc) / 2;
         var keyTpc = 14 + keySignature;
         var difference = keyTpc - averageTpc;
 


### PR DESCRIPTION
## Summary
- compute the chord average TPC using the minimum and maximum note values instead of all notes
- keep applying the adjustment across all notes while minimizing the gap to the key signature

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948487101d48328b76974f746b8bc93)