### PR TITLE
Log key signature changes during processing

### DIFF
--- a/RespellCSharpToDb.qml
+++ b/RespellCSharpToDb.qml
@@ -98,8 +98,14 @@ MuseScore {
             cursor.rewind(Cursor.START);
 
         var selectionEndTick = hasSelection ? curScore.selectionEndTick : -1;
+        var previousKeySignature = undefined;
 
         while (cursor.segment && (!hasSelection || cursor.tick < selectionEndTick)) {
+            if (previousKeySignature === undefined || cursor.keySignature !== previousKeySignature) {
+                console.log("Current keySignature:", cursor.keySignature);
+                previousKeySignature = cursor.keySignature;
+            }
+
             if (cursor.element && cursor.element.type === Element.CHORD)
                 processChord(cursor.element.notes, cursor.keySignature);
             cursor.next();


### PR DESCRIPTION
## Summary
- log the key signature value whenever it changes while processing the score
- track the previous key signature so the debug output appears only on changes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69484c3f08708328a93c91e476fb568b)