### PR TITLE
Simplify tonic-based respelling logic

### DIFF
--- a/RespellCSharpToDb.qml
+++ b/RespellCSharpToDb.qml
@@ -3,19 +3,45 @@ import MuseScore 3.0
 
 MuseScore {
     menuPath: "Plugins/Enharmonic Respeller/Remplacer quintes justes"
-    description: qsTr("Pour chaque accord, orthographie chaque note par rapport à la basse avec la distance de TPC minimale.")
+    description: qsTr("Pour chaque accord, orthographie chaque note en minimisant l'écart de TPC à la tonique et, à égalité, à la basse.")
     version: "1.3.0"
     requiresScore: true
 
-    function respellNotesRelativeToBass(notes) {
-        if (notes.length < 2)
+    function findBass(notes) {
+        var bass = notes[0];
+        for (var i = 1; i < notes.length; i++) {
+            if (notes[i].pitch < bass.pitch)
+                bass = notes[i];
+        }
+        return bass;
+    }
+
+    function chooseClosestTpc(candidates, targetTpc, tieTpc) {
+        var closestTpc = candidates[0];
+        var minimalDistance = Math.abs(closestTpc - targetTpc);
+        var tieDistance = tieTpc !== undefined ? Math.abs(closestTpc - tieTpc) : Number.MAX_VALUE;
+
+        for (var i = 1; i < candidates.length; i++) {
+            var candidate = candidates[i];
+            var distance = Math.abs(candidate - targetTpc);
+            var candidateTieDistance = tieTpc !== undefined ? Math.abs(candidate - tieTpc) : Number.MAX_VALUE;
+
+            if (distance < minimalDistance || (distance === minimalDistance && candidateTieDistance < tieDistance)) {
+                closestTpc = candidate;
+                minimalDistance = distance;
+                tieDistance = candidateTieDistance;
+            }
+        }
+
+        return closestTpc;
+    }
+
+    function respellChord(notes, keySignature) {
+        if (!notes.length)
             return;
 
-        var bassNote = notes[0];
-        for (var i = 1; i < notes.length; i++) {
-            if (notes[i].pitch < bassNote.pitch)
-                bassNote = notes[i];
-        }
+        var tonicTpc = keySignature + 14;
+        var bassNote = findBass(notes);
 
         var pitchClassToTpcs = {
             0: [2, 14, 26],
@@ -32,61 +58,19 @@ MuseScore {
             11: [7, 19, 31]
         };
 
+        var bassCandidates = pitchClassToTpcs[bassNote.pitch % 12];
+        bassNote.tpc = chooseClosestTpc(bassCandidates, tonicTpc);
+
         for (var j = 0; j < notes.length; j++) {
             var note = notes[j];
-
-            if (note === bassNote)
-                continue;
-
             var candidates = pitchClassToTpcs[note.pitch % 12];
-            var closestTpc = candidates[0];
-            var minimalDistance = Math.abs(closestTpc - bassNote.tpc);
-
-            for (var k = 1; k < candidates.length; k++) {
-                var distance = Math.abs(candidates[k] - bassNote.tpc);
-                if (distance < minimalDistance) {
-                    minimalDistance = distance;
-                    closestTpc = candidates[k];
-                }
-            }
-
-            note.tpc = closestTpc;
+            var tieTpc = note === bassNote ? undefined : bassNote.tpc;
+            note.tpc = chooseClosestTpc(candidates, tonicTpc, tieTpc);
         }
-    }
-
-    function applyKeySignatureAdjustment(notes, keySignature) {
-        if (!notes.length)
-            return;
-
-        var minTpc = notes[0].tpc;
-        var maxTpc = notes[0].tpc;
-
-        for (var i = 1; i < notes.length; i++) {
-            var tpc = notes[i].tpc;
-            if (tpc < minTpc)
-                minTpc = tpc;
-            if (tpc > maxTpc)
-                maxTpc = tpc;
-        }
-
-        var averageTpc = (minTpc + maxTpc) / 2;
-        var keyTpc = 14 + keySignature;
-        var difference = keyTpc - averageTpc;
-
-        if (Math.abs(difference) < 12)
-            return;
-
-        var adjustment = Math.round(difference / 12) * 12;
-        if (!adjustment)
-            return;
-
-        for (var j = 0; j < notes.length; j++)
-            notes[j].tpc += adjustment;
     }
 
     function processChord(notes, keySignature) {
-        respellNotesRelativeToBass(notes);
-        applyKeySignatureAdjustment(notes, keySignature);
+        respellChord(notes, keySignature);
     }
 
     function processSelection() {


### PR DESCRIPTION
## Summary
- compute tonic tpc from the key signature and respell each chord note to minimize distance to the tonic
- prefer spellings closer to the bass note when distances to the tonic are equal
- simplify chord processing helpers accordingly

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69484fff6ae8832885b16ca3ac4f41cf)