### PR TITLE
Enhance respell logic with average TPC pass

### DIFF
--- a/Enharmonic Respell.qml
+++ b/Enharmonic Respell.qml
@@ -47,6 +47,31 @@ MuseScore {
 
             note.tpc = closestTpc;
         }
+
+        // Compute the average TPC after the initial pass, then run a second pass
+        // to align each note toward this average spelling.
+        var totalTpc = 0;
+        for (var i = 0; i < notes.length; i++)
+            totalTpc += notes[i].tpc;
+
+        var meanTpc = totalTpc / notes.length;
+
+        for (var j = 0; j < notes.length; j++) {
+            var note = notes[j];
+            var candidates = pitchClassToTpcs[note.pitch % 12];
+            var closestToMean = candidates[0];
+            var minDistanceToMean = Math.abs(closestToMean - meanTpc);
+
+            for (var k = 1; k < candidates.length; k++) {
+                var distanceToMean = Math.abs(candidates[k] - meanTpc);
+                if (distanceToMean < minDistanceToMean) {
+                    minDistanceToMean = distanceToMean;
+                    closestToMean = candidates[k];
+                }
+            }
+
+            note.tpc = closestToMean;
+        }
     }
 
     function applyKeySignatureAdjustment(notes, keySignature) {


### PR DESCRIPTION
## Summary
- add a second respelling pass that aligns notes toward the chord’s average TPC after the initial note[0]-based pass

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69489c9e21b4832887a04c74838b3667)