### PR TITLE
Add console logging to respell workflow

### DIFF
--- a/Chord Pitch Respell.qml
+++ b/Chord Pitch Respell.qml
@@ -7,8 +7,12 @@ MuseScore {
     requiresScore: true
 
     function respellNotes(notes) {
-    if (!notes || notes.length < 2)
+    if (!notes || notes.length < 2) {
+        console.log("respellNotes: skipping because chord has less than two notes");
         return;
+    }
+
+    console.log("respellNotes: processing", notes.length, "notes");
 
     var pitchClassToTpcs = {
         0: [2, 14, 26],
@@ -38,6 +42,8 @@ MuseScore {
         residues.push(mod12(pitchClassToTpcs[pcs][0]));
     }
 
+    console.log("respellNotes: residues", residues);
+
     // 2) Find minimal arc on the circle (length 12) covering all residues.
     // Sort residues (keep duplicates).
     var s = residues.slice().sort(function(a,b){ return a-b; });
@@ -62,6 +68,8 @@ MuseScore {
 
     var start = bestStart;
     var end   = start + bestSpan;
+
+    console.log("respellNotes: best window", start, "to", end, "(span", bestSpan, ")");
 
     // 3) For each note, pick a candidate TPC that lies in [start, end] (allow +/-12 shifts).
     // Tie-break: closest to the chord reference (first note current tpc).
@@ -102,13 +110,16 @@ MuseScore {
         }
 
         note.tpc = chosen;
+        console.log("respellNotes: note", i, "pitch", note.pitch, "chosen TPC", chosen, "(candidates", candidates, ")");
     }
 }
 
 
     function applyKeySignatureAdjustment(notes, keySignature) {
-        if (!notes.length)
+        if (!notes.length) {
+            console.log("applyKeySignatureAdjustment: no notes provided");
             return;
+        }
 
         // Find the chord's mean TPC span
         var minTpc = notes[0].tpc;
@@ -122,6 +133,8 @@ MuseScore {
                 maxTpc = tpc;
         }
         var averageTpc = (minTpc + maxTpc) / 2;
+
+                console.log("applyKeySignatureAdjustment: keySignature", keySignature, "minTpc", minTpc, "maxTpc", maxTpc, "avg", averageTpc);
 		
 		// TpcAdjust weights the spelling towards the center.
 		// If TpcAdjust=1, spelling fully aligns with the key signature.
@@ -135,18 +148,24 @@ MuseScore {
 
 
         var adjustment = Math.round(difference / 12) * 12;
-        if (!adjustment)
+        if (!adjustment) {
+            console.log("applyKeySignatureAdjustment: no adjustment needed");
             return;
+        }
 
         // Shift the whole chord enharmonically to better fit the key context.
-        for (var j = 0; j < notes.length; j++)
+        for (var j = 0; j < notes.length; j++) {
             notes[j].tpc += adjustment;
+        }
+        console.log("applyKeySignatureAdjustment: applied adjustment", adjustment);
     }
 
     // Run both respelling steps on a single chord.
     function processChord(notes, keySignature) {
+        console.log("processChord: starting with", notes.length, "notes and key signature", keySignature);
         respellNotes(notes);
         applyKeySignatureAdjustment(notes, keySignature);
+        console.log("processChord: finished");
     }
 
 function processSelection() {
@@ -155,16 +174,19 @@ function processSelection() {
 
     // 1) No selection => nothing to process.
     if (!elems || elems.length === 0) {
+        console.log("processSelection: no selection, exiting");
         return;
     }
 
     // 2) Range selection => reliable start/end ticks.
     if (sel.isRange) {
+        console.log("processSelection: processing range selection");
         processRangeSelection(sel.startSegment.tick, sel.endSegment.tick);
         return;
     }
 
     // 3) List selection => iterate over the chosen elements.
+    console.log("processSelection: processing list selection");
     processListSelection(elems);
 }
 
@@ -173,10 +195,14 @@ function processRangeSelection(startTick, endTick) {
     var cursor = curScore.newCursor();
     cursor.rewind(Cursor.SELECTION_START);
 
+    console.log("processRangeSelection: from", startTick, "to", endTick);
+
     // Walk through every segment inside the selection and respell its chords.
     while (cursor.segment && cursor.tick < endTick) {
-        if (cursor.element && cursor.element.type === Element.CHORD)
+        if (cursor.element && cursor.element.type === Element.CHORD) {
+            console.log("processRangeSelection: processing chord at tick", cursor.tick, "track", cursor.track);
             processChord(cursor.element.notes, cursor.keySignature);
+        }
         cursor.next();
     }
 }
@@ -184,6 +210,8 @@ function processRangeSelection(startTick, endTick) {
 function processListSelection(elements) {
     var cursor = curScore.newCursor();
     var seenNotes = {};
+
+    console.log("processListSelection: processing", elements.length, "elements");
 
     for (var i = 0; i < elements.length; i++) {
         var e = elements[i];
@@ -211,13 +239,16 @@ function processListSelection(elements) {
 
     onRun: {
         if (!curScore) {
+            console.log("onRun: no score open, quitting");
             Qt.quit();
             return;
         }
 
+        console.log("onRun: starting respell process");
         curScore.startCmd();
         processSelection();
         curScore.endCmd();
+        console.log("onRun: finished respell process");
         Qt.quit();
     }
 }


### PR DESCRIPTION
## Summary
- add console logging across the respelling workflow for improved visibility
- log selection handling, key signature adjustments, and command lifecycle events

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949ae4851ec83289815177c1f1a0aac)