### PR TITLE
Add homonym penalty to window scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Enharmonic respelling tool optimized for MIDI-entered chords, preserving chord q
 Note that the plugin analyzes each chord independently, without using a time window. **As such, its logic could be applied directly to MuseScore’s core MIDI input. This plugin is intended as a proof of concept demonstrating improved enharmonic spelling behavior.**
 
 The core idea is to minimize the spread of [Tonal Pitch Classes](https://musescore.github.io/MuseScore_PluginAPI_Docs/plugins/html/tpc.html) across all notes of a chord, while also taking the current key signature into account.
-A configurable constant is used to down-weight the use of extreme accidentals (double flats and double sharps).
-As a tie-breaker, the algorithm also minimizes homonyms within a chord (e.g. G and G♯).
+A configurable constant is used to down-weight the use of extreme accidentals (double flats and double sharps), and a homonym penalty (default 3) discourages spellings that place homonyms (e.g. G and G♯) inside the same chord window.
 
 ### Parallel maj7 chords
 


### PR DESCRIPTION
## Summary
- score window candidates using span plus a configurable homonym penalty instead of a separate tie-break step
- adjust logging, comments, and documentation to describe the homonym-aware scoring

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949dbc3ce388328b3f603fc90d04ef1)