### PR TITLE
Sync written (`tpc2`) and concert (`tpc`) TPC when respelling chords

### DIFF
--- a/Chord Pitch Respell.qml
+++ b/Chord Pitch Respell.qml
@@ -231,7 +231,11 @@ MuseScore {
                 }
             }
 
+            var previousTpc = note.tpc;
             note.tpc = chosen;
+            if (note.tpc2 !== undefined && note.tpc2 !== null) {
+                note.tpc2 += (chosen - previousTpc);
+            }
             console.log("respellNotes: note", i, "pitch", note.pitch, "assigned TPC", chosen, "(candidates", candidates, ")");
         }
     }
@@ -308,6 +312,9 @@ MuseScore {
         // Apply translation to entire chord (preserves internal relationships)
         for (var j = 0; j < notes.length; j++) {
             notes[j].tpc += adjustment;
+            if (notes[j].tpc2 !== undefined && notes[j].tpc2 !== null) {
+                notes[j].tpc2 += adjustment;
+            }
         }
         console.log("applyKeySignatureAdjustment: applied adjustment", adjustment);
     }


### PR DESCRIPTION
### Motivation
- Ensure enharmonic respelling updates are global by keeping both concert pitch (`tpc`) and written pitch (`tpc2`) consistent.
- Prevent mismatches between internal harmonic respelling and the written representation used for display/parts.
- Apply key-signature driven translations to both concert and written TPC values so spellings remain coherent in context.

### Description
- In `respellNotes`, preserve the previous `tpc` and apply the delta to `tpc2` when present so written pitch follows the chosen enharmonic candidate.
- In `applyKeySignatureAdjustment`, add the same `adjustment` offset to `tpc2` for each note when `tpc2` is defined so key-signature shifts affect both TPCs.
- Keep existing logic and scoring for window selection and homonym penalties unchanged, only synchronizing `tpc2` updates with existing `tpc` changes.

### Testing
- No automated tests were executed for this plugin-only change.
- The change is limited to updating `tpc2` bookkeeping alongside existing `tpc` updates and relies on existing runtime logging for verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695810683c608328944f80ccb888dcf3)