### PR TITLE
Use note.tpc1 as authoritative TPC and propagate tpc1/tpc2 deltas

### DIFF
--- a/Chord Pitch Respell.qml
+++ b/Chord Pitch Respell.qml
@@ -212,6 +212,12 @@ MuseScore {
             return y;
         }
 
+        function setNoteTpcs(note, tpc) {
+            var dtpc = note.tpc2 - note.tpc1;
+            note.tpc1 = tpc;
+            note.tpc2 = tpc + dtpc;
+        }
+
         // Assignment for each note
         for (i = 0; i < notes.length; i++) {
             var note = notes[i];
@@ -231,7 +237,7 @@ MuseScore {
                 }
             }
 
-            note.tpc = chosen;
+            setNoteTpcs(note, chosen);
             console.log("respellNotes: note", i, "pitch", note.pitch, "assigned TPC", chosen, "(candidates", candidates, ")");
         }
     }
@@ -274,11 +280,11 @@ MuseScore {
         }
 
         // Calculate the TPC center of the chord (min/max average)
-        var minTpc = notes[0].tpc;
-        var maxTpc = notes[0].tpc;
+        var minTpc = notes[0].tpc1;
+        var maxTpc = notes[0].tpc1;
 
         for (var i = 1; i < notes.length; i++) {
-            var tpc = notes[i].tpc;
+            var tpc = notes[i].tpc1;
             if (tpc < minTpc)
                 minTpc = tpc;
             if (tpc > maxTpc)
@@ -307,7 +313,9 @@ MuseScore {
 
         // Apply translation to entire chord (preserves internal relationships)
         for (var j = 0; j < notes.length; j++) {
-            notes[j].tpc += adjustment;
+            var dtpc = notes[j].tpc2 - notes[j].tpc1;
+            notes[j].tpc1 += adjustment;
+            notes[j].tpc2 = notes[j].tpc1 + dtpc;
         }
         console.log("applyKeySignatureAdjustment: applied adjustment", adjustment);
     }


### PR DESCRIPTION
### Motivation
- Ensure all getter calculations use the displayed/heard distinction by reading TPCs from `tpc1` instead of the old `tpc` field. 
- Preserve instrument transposition offsets between `tpc1` and `tpc2` when assigning respellings and applying key-signature translations. 
- Avoid corrupting transposing instruments by updating both `tpc1` and `tpc2` consistently. 
- Keep Phase 1 respelling behavior while making Phase 2 key adjustments respect `tpc1` as the base.

### Description
- Added helper `setNoteTpcs(note, tpc)` which computes `dtpc = note.tpc2 - note.tpc1` and sets `note.tpc1 = tpc` and `note.tpc2 = tpc + dtpc` to preserve transposition delta. 
- Replaced direct assignments to `note.tpc` in the respelling loop with calls to `setNoteTpcs(note, chosen)`. 
- Switched key-signature center calculation to use `notes[i].tpc1` for `minTpc`, `maxTpc`, and average TPC. 
- When applying the enharmonic translation for key alignment, update `notes[j].tpc1` and recompute `notes[j].tpc2` using the preserved `dtpc` rather than modifying `note.tpc` directly.

### Testing
- No automated tests were executed as part of this change. 
- Code compiles/loads in the repository workspace (manual verification during development), but no CI/automated run was performed. 
- Recommend running plugin in MuseScore with both transposing and non-transposing instrument examples to validate behavior. 
- Recommend adding unit/CI checks for `tpc1`/`tpc2` propagation in future work.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69585b52a4688328926a3fb95e56836a)