### PR TITLE
Favor lower TPC windows in respell tie-breaker

### DIFF
--- a/Chord Pitch Respell.qml
+++ b/Chord Pitch Respell.qml
@@ -177,8 +177,8 @@ MuseScore {
                 windowScore < bestScore ? "< current best" : (windowScore === bestScore ? "= current best" : "> current best")
             );
 
-            // Prefer lower scores; break ties on smaller spans to keep compactness.
-            if (windowScore < bestScore || (windowScore === bestScore && span < bestSpan)) {
+            // Prefer lower scores; break ties on lower TPC windows (favoring flats).
+            if (windowScore < bestScore || (windowScore === bestScore && (chosenWindow === null || windowStart < chosenWindow.windowStart))) {
                 bestSpan = span;
                 bestScore = windowScore;
                 chosenWindow = {


### PR DESCRIPTION
### Motivation
- When candidate windows score equally, prefer enharmonic spellings with lower TPC values (favor flats) instead of breaking ties by span.
- This makes the respelling choice more consistent with a preference for "bémols" in tied situations.
- The in-code comment was updated to reflect the new tie-break behavior.

### Description
- In `Chord Pitch Respell.qml` the tie-breaker in `respellNotes` was changed from checking `span < bestSpan` to comparing `windowStart` against the current `chosenWindow` start (`chosenWindow === null || windowStart < chosenWindow.windowStart`).
- The comment above the condition was updated to: "Prefer lower scores; break ties on lower TPC windows (favoring flats)."
- No other algorithmic logic or homonym penalty behavior was modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69623b372bc88328864f75c9f850de03)